### PR TITLE
Updates

### DIFF
--- a/spec/syslog/logger_spec.cr
+++ b/spec/syslog/logger_spec.cr
@@ -77,5 +77,4 @@ describe Syslog::Logger do
     server.close
     message.should eq(expected_message)
   end
-
 end

--- a/spec/syslog/logger_spec.cr
+++ b/spec/syslog/logger_spec.cr
@@ -15,7 +15,7 @@ describe Syslog::Logger do
       expected_message = "<206>#{time_formatter.format(Time.new)} localhost \
         [#{Process.pid}]: [INFO] Hello, world! We use remote syslog!"
       logger.info("Hello, world! We use remote syslog!")
-      message = server.read(expected_message.bytesize)
+      message = server.gets(expected_message.bytesize)
       server.close
       message.should eq(expected_message)
     end
@@ -35,7 +35,7 @@ describe Syslog::Logger do
     expected_message = "<176>#{time_formatter.format(Time.new)} localhost \
       [#{Process.pid}]: [INFO] Hello, world! We use remote syslog!"
     logger.info("Hello, world! We use remote syslog!")
-    message = server.read(expected_message.bytesize)
+    message = server.gets(expected_message.bytesize)
     server.close
     message.should eq(expected_message)
   end
@@ -54,7 +54,7 @@ describe Syslog::Logger do
     expected_message = "<206>#{time_formatter.format(Time.new)} app.company.com \
       [#{Process.pid}]: [INFO] Hello, world! We use remote syslog!"
     logger.info("Hello, world! We use remote syslog!")
-    message = server.read(expected_message.bytesize)
+    message = server.gets(expected_message.bytesize)
     server.close
     message.should eq(expected_message)
   end
@@ -73,7 +73,7 @@ describe Syslog::Logger do
     expected_message = "<206>#{time_formatter.format(Time.new)} localhost \
       GreatApp [#{Process.pid}]: [INFO] Hello, world! We use remote syslog!"
     logger.info("Hello, world! We use remote syslog!")
-    message = server.read(expected_message.bytesize)
+    message = server.gets(expected_message.bytesize)
     server.close
     message.should eq(expected_message)
   end

--- a/spec/syslog/message_spec.cr
+++ b/spec/syslog/message_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 describe Syslog::Message do
   it "creates well formed message" do
-    io = StringIO.new
+    io = MemoryIO.new
     message = Syslog::Message.new(
       Syslog::Facility::KERNEL,
       Syslog::Severity::ALERT,

--- a/src/syslog.cr
+++ b/src/syslog.cr
@@ -1,5 +1,4 @@
 require "./syslog/*"
 
 module Syslog
-  
 end

--- a/src/syslog/facility.cr
+++ b/src/syslog/facility.cr
@@ -1,6 +1,6 @@
 module Syslog
   enum Facility
-    #kernel messages
+    # kernel messages
     KERNEL
     # user-level messages
     USER

--- a/src/syslog/logger.cr
+++ b/src/syslog/logger.cr
@@ -9,20 +9,19 @@ module Syslog
     property :level
 
     def initialize(
-      @hostname = "localhost",
-      @appname = nil,
-      @facility = Facility::LOCAL4,
-      @remote = false,
-      @syslog_host = "localhost",
-      @syslog_port = 514
-    )
-    @level = Severity::INFO
+                   @hostname = "localhost",
+                   @appname = nil,
+                   @facility = Facility::LOCAL4,
+                   @remote = false,
+                   @syslog_host = "localhost",
+                   @syslog_port = 514)
+      @level = Severity::INFO
       if remote
         udp_socket = UDPSocket.new
         udp_socket.connect(@syslog_host, @syslog_port)
         @socket = udp_socket
       else
-        @socket  = UNIXSocket.new("/dev/log", Socket::Type::DGRAM)
+        @socket = UNIXSocket.new("/dev/log", Socket::Type::DGRAM)
       end
     end
 
@@ -55,7 +54,7 @@ module Syslog
     end
 
     def debug(message : String)
-    log(Severity::DEBUG, message)
+      log(Severity::DEBUG, message)
     end
 
     private def log(severity : Severity, message : String)
@@ -73,6 +72,5 @@ module Syslog
       @socket << message.to_s
       @socket.flush
     end
-
   end
 end

--- a/src/syslog/message.cr
+++ b/src/syslog/message.cr
@@ -2,22 +2,21 @@ module Syslog
   # Message formatted according to syslog specification.
   class Message
     def initialize(
-      @facility : Facility,
-      @severity : Severity,
-      @timestamp : String,
-      @hostname : String,
-      @appname : (String | Nil),
-      @message : String
-    )
+                   @facility : Facility,
+                   @severity : Severity,
+                   @timestamp : String,
+                   @hostname : String,
+                   @appname : (String | Nil),
+                   @message : String)
     end
 
-     def to_s(io : IO)
-       io << "<#{@facility.value}#{@severity.value}>#{@timestamp} #{@hostname} "
-       if @appname
-         io << "#{@appname} "
-       end
-       io << "[#{Process.pid}]: "
-       io << "[#{@severity}] #{@message}"
-     end
+    def to_s(io : IO)
+      io << "<#{@facility.value}#{@severity.value}>#{@timestamp} #{@hostname} "
+      if @appname
+        io << "#{@appname} "
+      end
+      io << "[#{Process.pid}]: "
+      io << "[#{@severity}] #{@message}"
+    end
   end
 end


### PR DESCRIPTION
Commits, in reverse order:
- 8df75be style only: `crystal tool format` automatic changes
- 5cddc26 StringIO was renamed to MemoryIO
- bd61809 Update overloads methods for UDPSocket renames

I was using this lib as an inspiration, found a few things that were not working with the most recent releases of Crystal.

The biggest "change" is stylistic, thanks to `crystal tool format`. Feel free to reject that if you like, I'm happy to update the pull range to exclude that commit.
