### PR TITLE
Update test syntax for Crystal > 0.20.0

### DIFF
--- a/spec/syslog/message_spec.cr
+++ b/spec/syslog/message_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 describe Syslog::Message do
   it "creates well formed message" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     message = Syslog::Message.new(
       Syslog::Facility::KERNEL,
       Syslog::Severity::ALERT,


### PR DESCRIPTION
MemoryIO was renamed to IO::Memory in 0.20.0 and removed in 0.20.1.

Testing-only change.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>