### PR TITLE
Support setting the log level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ require "syslog"
 # - application hostname: localhost
 # - application name: ""
 # - syslog facility: local4
-# - log level: INFO
 logger = Syslog::Logger.new
 logger.info("Something interesting happened")
 
@@ -36,10 +35,16 @@ logger = Syslog::Logger.new(
     syslog_host: "logger.company.com",
     syslog_port: 1234,
     appname: "application.company.com",
-    facility: Syslog::Facility::USER
+    facility: Syslog::Facility::USER,
+    level: Syslog::Severity::WARN
 )
 
 logger.error("Something bad happened")
+
+# Set the log level
+logger.level = Syslog::Severity::DEBUG
+
+logger.debug("Some debug message")
 
 ```
 ## Contributing

--- a/spec/syslog/logger_spec.cr
+++ b/spec/syslog/logger_spec.cr
@@ -40,6 +40,69 @@ describe Syslog::Logger do
     message.should eq(expected_message)
   end
 
+  it "logs with custom level" do
+    time_formatter = Time::Format.new("%b %d %H:%M:%S")
+    server = UDPSocket.new
+    server.bind("localhost", 1234)
+
+    logger = Syslog::Logger.new(
+      level: Syslog::Severity::DEBUG,
+      facility: Syslog::Facility::LOCAL1,
+      remote: true,
+      syslog_host: "localhost",
+      syslog_port: 1234
+    )
+    debug_message = "<177>#{time_formatter.format(Time.new)} localhost \
+      [#{Process.pid}]: [DEBUG] Hello, world! We use remote syslog!"
+
+    logger.debug("Hello, world! We use remote syslog!")
+    message, _client_addr = server.receive
+
+
+    warn_message = "<174>#{time_formatter.format(Time.new)} localhost \
+      [#{Process.pid}]: [WARNING] Hello, world! We use remote syslog!"
+
+    logger.warn("Hello, world! We use remote syslog!")
+    message2, _client_addr = server.receive
+    server.close
+
+    message.should eq(debug_message)
+    message2.should eq(warn_message)
+  end
+
+  it "can change the log level" do
+    time_formatter = Time::Format.new("%b %d %H:%M:%S")
+    server = UDPSocket.new
+    server.bind("localhost", 1234)
+    server.read_timeout = Time::Span.new(nanoseconds: 300_000_000)
+
+    logger = Syslog::Logger.new(
+      facility: Syslog::Facility::LOCAL1,
+      level: Syslog::Severity::INFO,
+      remote: true,
+      syslog_host: "localhost",
+      syslog_port: 1234
+    )
+
+    # We shouldn't get debug level messages
+    logger.debug("Hello, world! We use remote syslog!")
+    expect_raises(IO::Timeout) do
+      _message, _client_addr = server.receive
+    end
+
+
+    logger.level = Syslog::Severity::DEBUG
+
+    # Now we should
+    debug_message = "<177>#{time_formatter.format(Time.new)} localhost \
+      [#{Process.pid}]: [DEBUG] Hello, world! We use remote syslog!"
+    logger.debug("Hello, world! We use remote syslog!")
+    message2, _client_addr = server.receive
+    server.close
+
+    message2.should eq(debug_message)
+  end
+
   it "logs with custom hostname" do
     time_formatter = Time::Format.new("%b %d %H:%M:%S")
     server = UDPSocket.new

--- a/src/syslog/logger.cr
+++ b/src/syslog/logger.cr
@@ -6,16 +6,16 @@ module Syslog
 
     @socket : Socket
 
-    @level : Syslog::Severity
+    property :level
 
     def initialize(
                    @hostname = "localhost",
                    @appname : String? = nil,
                    @facility = Facility::LOCAL4,
+                   @level = Severity::INFO,
                    @remote = false,
                    @syslog_host = "localhost",
                    @syslog_port = 514)
-      @level = Severity::INFO
       if remote
         udp_socket = UDPSocket.new
         udp_socket.connect(@syslog_host, @syslog_port)


### PR DESCRIPTION
Set the log level either in the constructor or via the 'level' property.

For example:

```crystal
logger = Syslog::Logger.new(
  facility: Syslog::Facility::LOCAL1,
  level: Syslog::Severity::INFO
)

# .. then optionally change the level later
logger.level = Syslog::Severity::DEBUG
```

In my scenario we read the log level from a config file, so we might end up changing it after the object is created.

Thanks for the shard, it's just what we needed.

